### PR TITLE
two new sunbeam extensions

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,6 @@
 const sunbeam_extensions = [
+    {"owner": "scottdaniel", "repo": "sbx_demic"},
+    {"owner": "scottdaniel", "repo": "sbx_vsearch"},
     {"owner": "sunbeam-labs", "repo": "sbx_report"},
     {"owner": "sunbeam-labs", "repo": "sbx_coassembly"},
     {"owner": "sunbeam-labs", "repo": "sbx_metaphlan"},

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 const sunbeam_extensions = [
+    {"owner": "scottdaniel", "repo": "sbx_centrifuge"},
     {"owner": "scottdaniel", "repo": "sbx_demic"},
     {"owner": "scottdaniel", "repo": "sbx_vsearch"},
     {"owner": "sunbeam-labs", "repo": "sbx_report"},


### PR DESCRIPTION
sbx_demic is for generating peak-to-trough ratios of co-assembled metagenomes from reads

sbx_vsearch is a simple extensions for aligning reads to arbitrary fasta files